### PR TITLE
Add role-based access control

### DIFF
--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -8,6 +8,10 @@ use Illuminate\Support\Facades\Storage;
 
 class PostController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('role:admin')->except(['index', 'show']);
+    }
     public function index()
     {
         $posts = Post::latest()->get();

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RoleMiddleware
+{
+    public function handle(Request $request, Closure $next, string $role): Response
+    {
+        $user = $request->user();
+
+        if (!$user || $user->role !== $role) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'role' => \App\Http\Middleware\RoleMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,6 +28,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'role' => 'user',
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/migrations/2025_05_25_000000_add_role_to_users_table.php
+++ b/database/migrations/2025_05_25_000000_add_role_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('user');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/tests/Feature/PostAuthorizationTest.php
+++ b/tests/Feature/PostAuthorizationTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PostAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_non_admin_cannot_create_post(): void
+    {
+        $user = User::factory()->create(['role' => 'user']);
+
+        $response = $this->actingAs($user)->post('/posts', [
+            'title' => 'Unauthorized',
+            'content' => 'Nope',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseCount('posts', 0);
+    }
+}
+

--- a/tests/Feature/PostImageUploadTest.php
+++ b/tests/Feature/PostImageUploadTest.php
@@ -7,6 +7,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Tests\TestCase;
 use App\Models\Post;
+use App\Models\User;
 
 class PostImageUploadTest extends TestCase
 {
@@ -16,7 +17,9 @@ class PostImageUploadTest extends TestCase
     {
         Storage::fake('public');
 
-        $response = $this->post('/posts', [
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $response = $this->actingAs($user)->post('/posts', [
             'title' => 'With Image',
             'content' => 'Content',
             'image' => UploadedFile::fake()->image('photo.jpg'),


### PR DESCRIPTION
## Summary
- add `role` column migration and update `User` model
- create middleware to restrict access by role
- register role middleware
- protect post management routes
- extend user factory with default role
- update post image upload test to use admin user
- add authorization test for non-admins

## Testing
- `phpunit --version` *(fails: command not found)*